### PR TITLE
Pass auth token via header for get, post, delete

### DIFF
--- a/app/services/github.py
+++ b/app/services/github.py
@@ -32,21 +32,21 @@ class GitHub():
 
     def get(self, route_url, params = {}):
         url = api_url + route_url
-        params['access_token'] = self.access_token
+        headers = {'Authorization' : 'token ' + self.access_token}
 
-        return requests.get(url, params=params).json()
+        return requests.get(url, params=params, headers=headers).json()
 
     def post(self, route_url, params = {}):
         url = api_url + route_url
-        params['access_token']  = self.access_token
+        headers = {'Authorization' : 'token ' + self.access_token}
 
-        return requests.post(url, params=params).json()
+        return requests.post(url, params=params, headers=headers).json()
 
     def delete(self, route_url, params = {}):
         url = api_url + route_url
-        params['access_token']  = self.access_token
+        headers = {'Authorization' : 'token ' + self.access_token}
 
-        return requests.delete(url, params=params)
+        return requests.delete(url, params=params, headers=headers)
 
     @staticmethod
     def get_user_from_token(access_token):


### PR DESCRIPTION
Hi! 
I saw your pull request on the issue of the depreciated github API param auth and think that these additional code changes may be needed as well in order to access the '/tutorial/requesting' page.
Let me know what you think! 
Thanks. :)